### PR TITLE
Improve serde errors using serde_path_to_error

### DIFF
--- a/lambda/Cargo.toml
+++ b/lambda/Cargo.toml
@@ -24,6 +24,7 @@ futures-util = "0.3.8"
 hyper = { version = "0.14", features = ["client", "server", "tcp", "http1", "http2"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.39"
+serde_path_to_error = "0.1"
 tower-service = "0.3"
 bytes = "1.0.0"
 http = "0.2"

--- a/lambda/examples/error-handling.rs
+++ b/lambda/examples/error-handling.rs
@@ -1,5 +1,6 @@
 /// See https://github.com/awslabs/aws-lambda-rust-runtime for more info on Rust runtime for AWS Lambda
 use lamedh_runtime::{handler_fn, run, Context, Error};
+use serde::de::IntoDeserializer;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::fs::File;
@@ -66,7 +67,7 @@ async fn main() -> Result<(), Error> {
 /// The actual handler of the Lambda request.
 pub(crate) async fn func(event: Value, ctx: Context) -> Result<Value, Error> {
     // check what action was requested
-    match serde_json::from_value::<Request>(event)?.event_type {
+    match serde_path_to_error::deserialize::<_, Request>(event.into_deserializer())?.event_type {
         EventType::SimpleError => {
             // generate a simple text message error using `simple_error` crate
             return Err(Box::new(simple_error::SimpleError::new("A simple error as requested!")));

--- a/lambda/src/lib.rs
+++ b/lambda/src/lib.rs
@@ -220,7 +220,7 @@ where
         let mut ctx: Context = Context::try_from(parts.headers)?;
         ctx.env_config = Config::from_env()?;
         let body = hyper::body::to_bytes(body).await?;
-        let body = serde_json::from_slice(&body)?;
+        let body = serde_path_to_error::deserialize(&mut serde_json::Deserializer::from_slice(&body))?;
 
         let request_id = &ctx.request_id.clone();
         let f = handler.call(body, ctx);


### PR DESCRIPTION
Currently, event deserialization errors can be difficult to diagnose. For example, a Lambda function may fail with the following error when the event type specifies a `u32` instead of a `String` for a field named `version`:
```
invalid type: string "1", expected u32 at line 1 column 14
```

This PR wraps the `serde_json` deserialization using the `serde_path_to_error` crate, which returns more helpful error messages that identify the specific field that failed to deserialize. With this change, the error above becomes:
```
version: invalid type: string "1", expected u32 at line 1 column 14
```

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
